### PR TITLE
Fixed memory readout

### DIFF
--- a/src/Daemon/index.js
+++ b/src/Daemon/index.js
@@ -58,8 +58,8 @@ class Daemon {
             cacheInterval: this.cache,
             memory: {
                 total: memory.total,
-                used: memory.used,
-                free: memory.free,
+                used: (memory.total-memory.available),
+                free: (memory.free+memory.available),
             },
             disk: {
                 total: disk.reduce((last, current) => last.size + current.size, 0) || disk[0].size,


### PR DESCRIPTION
Basically this commit fixes the memory readout for the daemon. Before it was only reading the "free" free memory, which is often used up completely by the OS and turned into "available memory", which is a pre processed memory which is ready to be allocated to a new process, while pre processed, it is still free. This fix will also make the bot read the available memory and count it as free memory too.

In my specific case, it was saying 61gb ram was used out of 64, which is not true and after further investigation, only 12-13gb was used with the rest being pre processed "available" memory. It is still free memory but just more ready for allocation.